### PR TITLE
feat: Add session bookends POC with preparation and reflection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "next": "^15.5.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^11.1.0"
@@ -10913,6 +10914,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "next": "^15.5.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0"

--- a/src/app/checkin/page.tsx
+++ b/src/app/checkin/page.tsx
@@ -1,14 +1,18 @@
 'use client'
 
 import React, { useState } from 'react'
-import { MessageCircle, Clock, Users, ArrowRight, Play, Settings } from 'lucide-react'
+import { MessageCircle, Clock, Users, ArrowRight, Play, Settings, Sparkles, FileText } from 'lucide-react'
 import { MotionBox, StaggerContainer, StaggerItem } from '@/components/ui/motion'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import Link from 'next/link'
 import { CardStack } from '@/components/ui/SwipeGestures'
 import { SessionSettingsProvider, useSessionSettings } from '@/contexts/SessionSettingsContext'
 import { SessionRulesCard } from '@/components/checkin/SessionRulesCard'
 import { SessionSettingsDemo } from '@/components/demo/SessionSettingsDemo'
+import { BookendsProvider, useBookends } from '@/contexts/BookendsContext'
+import { PreparationModal } from '@/components/bookends/PreparationModal'
+import { ReflectionForm } from '@/components/bookends/ReflectionForm'
 
 const checkInCategories = [
   {
@@ -46,6 +50,7 @@ function CheckInPageContent() {
   const [showCardStack, setShowCardStack] = useState(false)
   const { getActiveSettings } = useSessionSettings()
   const sessionSettings = getActiveSettings()
+  const { preparation, openPreparationModal, openReflectionModal } = useBookends()
   
   // Convert categories to swipeable cards
   const categoryCards = checkInCategories.map(category => ({
@@ -124,8 +129,24 @@ function CheckInPageContent() {
             <p className="text-gray-600 mt-1">
               Start with our guided quick check-in
             </p>
+            {preparation?.myTopics?.length ? (
+              <Badge className="mt-2 bg-pink-100 text-pink-700 border-pink-300">
+                <Sparkles className="h-3 w-3 mr-1" />
+                {preparation.myTopics.length} topics prepared
+              </Badge>
+            ) : null}
           </div>
           <div className="flex gap-2 flex-wrap">
+            {!preparation?.myTopics?.length && (
+              <Button 
+                variant="outline" 
+                onClick={openPreparationModal}
+                className="text-sm sm:text-base"
+              >
+                <FileText className="h-4 w-4 mr-1 sm:mr-2" />
+                <span className="hidden xs:inline">Prepare </span>Topics
+              </Button>
+            )}
             <Button className="bg-pink-600 hover:bg-pink-700 text-sm sm:text-base">
               <Play className="h-4 w-4 mr-1 sm:mr-2" />
               <span className="hidden xs:inline">Start </span>Now
@@ -262,6 +283,23 @@ function CheckInPageContent() {
           </div>
         </div>
       </div>
+
+      {/* Modals */}
+      <PreparationModal />
+      <ReflectionForm sessionId="demo-session" />
+
+      {/* Demo Reflection Button (for testing) */}
+      <div className="fixed bottom-20 right-4 z-40">
+        <Button
+          onClick={openReflectionModal}
+          size="sm"
+          variant="outline"
+          className="shadow-lg"
+        >
+          <Sparkles className="h-4 w-4 mr-2" />
+          Test Reflection
+        </Button>
+      </div>
     </MotionBox>
   )
 }
@@ -269,7 +307,9 @@ function CheckInPageContent() {
 export default function CheckInPage() {
   return (
     <SessionSettingsProvider>
-      <CheckInPageContent />
+      <BookendsProvider>
+        <CheckInPageContent />
+      </BookendsProvider>
     </SessionSettingsProvider>
   )
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,8 +14,11 @@ import { PullToRefresh } from '@/components/ui/PullToRefresh'
 import { MobileActionBar } from '@/components/ui/PrimaryActionFAB'
 import { simplifiedMockReminders } from '@/lib/mock-reminders'
 import { isToday } from 'date-fns'
+import { BookendsProvider } from '@/contexts/BookendsContext'
+import { PrepBanner } from '@/components/bookends/PrepBanner'
+import { PreparationModal } from '@/components/bookends/PreparationModal'
 
-export default function DashboardPage() {
+function DashboardContent() {
   const [refreshKey, setRefreshKey] = useState(0)
   const [todayRemindersCount, setTodayRemindersCount] = useState(0)
 
@@ -45,6 +48,12 @@ export default function DashboardPage() {
             Your relationship command center
           </p>
         </div>
+
+      {/* Session Preparation Banner */}
+      <PrepBanner />
+      
+      {/* Preparation Modal */}
+      <PreparationModal />
 
       {/* Quick Actions */}
       <StaggerContainer className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
@@ -163,5 +172,13 @@ export default function DashboardPage() {
         <MobileActionBar />
       </MotionBox>
     </PullToRefresh>
+  )
+}
+
+export default function DashboardPage() {
+  return (
+    <BookendsProvider>
+      <DashboardContent />
+    </BookendsProvider>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Header } from '@/components/layout/Header'
 import { Navigation } from '@/components/layout/Navigation'
 import PageTransition from '@/components/ui/PageTransition'
 import SwipeNavigation from '@/components/ui/SwipeGestures'
+import { Toaster } from 'sonner'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -110,6 +111,16 @@ export default function RootLayout({
         <link rel="manifest" href="/manifest.json" />
       </head>
       <body className={`${inter.className} gradient-romantic min-h-screen antialiased touch-manipulation`}>
+          <Toaster 
+            position="top-center" 
+            toastOptions={{
+              style: {
+                background: '#fff',
+                color: '#333',
+                border: '1px solid #e5e5e5',
+              },
+            }}
+          />
           <div className="flex min-h-screen lg:h-screen safe-area-inset">
             {/* Desktop Sidebar Navigation */}
             <Navigation />

--- a/src/components/bookends/PrepBanner.tsx
+++ b/src/components/bookends/PrepBanner.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import React from 'react'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { motion } from 'framer-motion'
+import { Calendar, Clock, Sparkles, X } from 'lucide-react'
+import { useBookends } from '@/contexts/BookendsContext'
+import { format, addDays, isToday, isTomorrow } from 'date-fns'
+
+export function PrepBanner() {
+  const { 
+    preparation, 
+    hasSeenPrepReminder,
+    openPreparationModal 
+  } = useBookends()
+
+  // Mock next session time (for demo)
+  const nextSessionDate = addDays(new Date(), 1)
+  nextSessionDate.setHours(19, 0, 0, 0) // 7 PM tomorrow
+
+  const getTimeUntilSession = () => {
+    if (isToday(nextSessionDate)) return 'Today'
+    if (isTomorrow(nextSessionDate)) return 'Tomorrow'
+    return format(nextSessionDate, 'EEEE')
+  }
+
+  // Don't show if already prepared or dismissed
+  if (preparation?.myTopics?.length || hasSeenPrepReminder) {
+    // Show compact version if topics are prepared
+    if (preparation?.myTopics?.length) {
+      return (
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mb-6"
+        >
+          <Card className="p-4 bg-gradient-to-r from-pink-50 to-purple-50 border-pink-200">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="bg-white rounded-full p-2">
+                  <Sparkles className="h-5 w-5 text-pink-600" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-900">
+                    You&apos;ve prepared {preparation.myTopics.length} {preparation.myTopics.length === 1 ? 'topic' : 'topics'} for your next check-in
+                  </p>
+                  <p className="text-xs text-gray-600">
+                    {preparation.partnerTopics?.length 
+                      ? `Jordan has added ${preparation.partnerTopics.length} ${preparation.partnerTopics.length === 1 ? 'topic' : 'topics'} too`
+                      : 'Waiting for Jordan to add topics'}
+                  </p>
+                </div>
+              </div>
+              <Button 
+                variant="ghost" 
+                size="sm"
+                onClick={openPreparationModal}
+              >
+                View Topics
+              </Button>
+            </div>
+          </Card>
+        </motion.div>
+      )
+    }
+    return null
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="mb-6"
+    >
+      <Card className="relative overflow-hidden bg-gradient-to-r from-pink-50 via-purple-50 to-blue-50 border-pink-200">
+        {/* Animated background pattern */}
+        <div className="absolute inset-0 opacity-10">
+          <div className="absolute -top-4 -left-4 w-24 h-24 bg-pink-400 rounded-full blur-xl" />
+          <div className="absolute -bottom-4 -right-4 w-32 h-32 bg-purple-400 rounded-full blur-xl" />
+        </div>
+
+        <div className="relative p-6">
+          <div className="flex items-start justify-between">
+            <div className="flex-1">
+              <div className="flex items-center gap-2 mb-3">
+                <Calendar className="h-5 w-5 text-pink-600" />
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Prepare for Your {getTimeUntilSession()} Check-In
+                </h3>
+              </div>
+              
+              <p className="text-sm text-gray-700 mb-4">
+                Take a moment to think about what you&apos;d like to discuss with Jordan. 
+                Adding topics beforehand helps make your check-in more focused and meaningful.
+              </p>
+
+              <div className="flex items-center gap-4 text-sm text-gray-600 mb-4">
+                <div className="flex items-center gap-1">
+                  <Clock className="h-4 w-4" />
+                  <span>Takes 2-3 minutes</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Sparkles className="h-4 w-4" />
+                  <span>Jordan can add topics too</span>
+                </div>
+              </div>
+
+              <div className="flex gap-3">
+                <Button 
+                  onClick={openPreparationModal}
+                  className="bg-pink-600 hover:bg-pink-700"
+                >
+                  Prepare Topics
+                </Button>
+                <Button 
+                  variant="outline"
+                  onClick={() => {
+                    // In a real app, this would update the context to dismiss
+                    console.log('Reminder dismissed')
+                  }}
+                >
+                  Maybe Later
+                </Button>
+              </div>
+            </div>
+
+            {/* Dismiss button */}
+            <button
+              onClick={() => {
+                // In a real app, this would update the context
+                console.log('Banner dismissed')
+              }}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+      </Card>
+    </motion.div>
+  )
+}

--- a/src/components/bookends/PreparationModal.tsx
+++ b/src/components/bookends/PreparationModal.tsx
@@ -1,0 +1,246 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card } from '@/components/ui/card'
+import { motion, AnimatePresence } from 'framer-motion'
+import { X, Plus, GripVertical, Users, Sparkles, Clock } from 'lucide-react'
+import { useBookends } from '@/contexts/BookendsContext'
+import { QUICK_TOPICS } from '@/types/bookends'
+import { cn } from '@/lib/utils'
+
+export function PreparationModal() {
+  const {
+    preparation,
+    isPreparationModalOpen,
+    closePreparationModal,
+    addMyTopic,
+    removeMyTopic,
+    reorderMyTopics,
+    simulatePartnerTopics
+  } = useBookends()
+
+  const [customTopic, setCustomTopic] = useState('')
+  const [showPartnerTopics, setShowPartnerTopics] = useState(false)
+  const [partnerLoading, setPartnerLoading] = useState(false)
+
+  // Simulate partner adding topics
+  useEffect(() => {
+    if (isPreparationModalOpen && !preparation?.partnerTopics?.length && !partnerLoading) {
+      setPartnerLoading(true)
+      simulatePartnerTopics()
+      
+      // Show partner section after delay
+      setTimeout(() => {
+        setShowPartnerTopics(true)
+        setPartnerLoading(false)
+      }, 3000)
+    }
+  }, [isPreparationModalOpen, preparation, simulatePartnerTopics, partnerLoading])
+
+  const handleAddCustomTopic = () => {
+    if (customTopic.trim()) {
+      addMyTopic(customTopic.trim(), false)
+      setCustomTopic('')
+    }
+  }
+
+  const handleQuickTopicClick = (topic: typeof QUICK_TOPICS[0]) => {
+    // Check if already added
+    const isAdded = preparation?.myTopics.some(t => 
+      t.isQuickTopic && t.content === topic.label
+    )
+    
+    if (!isAdded) {
+      addMyTopic(topic.label, true)
+    }
+  }
+
+  const myTopics = preparation?.myTopics || []
+  const partnerTopics = preparation?.partnerTopics || []
+
+  return (
+    <Dialog open={isPreparationModalOpen} onOpenChange={closePreparationModal}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto bg-white/95 backdrop-blur-md border-rose-200/40">
+        <DialogHeader>
+          <DialogTitle className="text-2xl font-bold bg-gradient-to-r from-rose-500 to-pink-500 bg-clip-text text-transparent">
+            Prepare for Your Check-In
+          </DialogTitle>
+          <DialogDescription className="text-gray-600">
+            Select topics you&apos;d like to discuss. Your partner can add their own topics too.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 mt-4">
+          {/* Quick Topics */}
+          <div>
+            <h3 className="text-sm font-medium text-rose-700 mb-3">Quick Topics</h3>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              {QUICK_TOPICS.map((topic) => {
+                const isAdded = myTopics.some(t => 
+                  t.isQuickTopic && t.content === topic.label
+                )
+                return (
+                  <motion.button
+                    key={topic.id}
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    onClick={() => handleQuickTopicClick(topic)}
+                    className={cn(
+                      "flex items-center gap-2 p-3 rounded-lg border transition-all text-left",
+                      isAdded 
+                        ? "bg-pink-50 border-pink-300 text-pink-700"
+                        : "bg-white border-gray-200 hover:border-gray-300"
+                    )}
+                    disabled={isAdded}
+                  >
+                    <span className="text-xl">{topic.icon}</span>
+                    <span className="text-sm">{topic.label}</span>
+                    {isAdded && <span className="text-xs ml-auto">✓</span>}
+                  </motion.button>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Custom Topic Input */}
+          <div>
+            <h3 className="text-sm font-medium text-rose-700 mb-3">Add Custom Topic</h3>
+            <div className="flex gap-2">
+              <Input
+                value={customTopic}
+                onChange={(e) => setCustomTopic(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleAddCustomTopic()}
+                placeholder="Something specific you want to discuss..."
+                className="flex-1"
+              />
+              <Button 
+                onClick={handleAddCustomTopic}
+                disabled={!customTopic.trim()}
+                size="sm"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* My Topics List */}
+          {myTopics.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium text-rose-700 mb-3">
+                Your Topics ({myTopics.length})
+              </h3>
+              <div className="space-y-2">
+                <AnimatePresence>
+                  {myTopics.map((topic) => (
+                    <motion.div
+                      key={topic.id}
+                      layout
+                      initial={{ opacity: 0, y: -10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, x: -100 }}
+                      className="flex items-center gap-2 p-3 bg-pink-50 rounded-lg border border-pink-200"
+                    >
+                      <GripVertical className="h-4 w-4 text-gray-400 cursor-grab" />
+                      <span className="flex-1 text-sm">{topic.content}</span>
+                      <button
+                        onClick={() => removeMyTopic(topic.id)}
+                        className="text-gray-500 hover:text-red-500 transition-colors"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+              </div>
+            </div>
+          )}
+
+          {/* Partner Topics */}
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <Users className="h-4 w-4 text-gray-500" />
+              <h3 className="text-sm font-medium text-rose-700">
+                Jordan&apos;s Topics
+              </h3>
+              {partnerLoading && (
+                <span className="text-xs text-gray-500 ml-auto">
+                  Jordan is preparing...
+                </span>
+              )}
+            </div>
+
+            {showPartnerTopics && partnerTopics.length > 0 ? (
+              <div className="space-y-2">
+                <AnimatePresence>
+                  {partnerTopics.map((topic, index) => (
+                    <motion.div
+                      key={topic.id}
+                      initial={{ opacity: 0, x: 20 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{ delay: index * 0.1 }}
+                      className="p-3 bg-blue-50 rounded-lg border border-blue-200"
+                    >
+                      <span className="text-sm">{topic.content}</span>
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+              </div>
+            ) : partnerLoading ? (
+              <div className="flex items-center justify-center p-8 bg-gray-50 rounded-lg border border-gray-200">
+                <div className="text-center">
+                  <Sparkles className="h-8 w-8 text-gray-400 mx-auto mb-2 animate-pulse" />
+                  <p className="text-sm text-gray-500">Waiting for Jordan...</p>
+                </div>
+              </div>
+            ) : (
+              <div className="p-4 bg-gray-50 rounded-lg border border-gray-200">
+                <p className="text-sm text-gray-500">No topics from Jordan yet</p>
+              </div>
+            )}
+          </div>
+
+          {/* Combined Agenda Preview */}
+          {(myTopics.length > 0 || partnerTopics.length > 0) && (
+            <Card className="p-4 bg-gradient-to-r from-pink-50 to-blue-50">
+              <div className="flex items-center gap-2 mb-3">
+                <Clock className="h-4 w-4 text-gray-600" />
+                <h3 className="text-sm font-medium text-rose-700">Session Agenda</h3>
+                <span className="text-xs text-gray-500 ml-auto">
+                  {myTopics.length + partnerTopics.length} topics total
+                </span>
+              </div>
+              <div className="text-xs text-gray-600">
+                <p>• {myTopics.length} topics from you</p>
+                <p>• {partnerTopics.length} topics from Jordan</p>
+                <p className="mt-2 text-gray-500">
+                  Estimated time: {(myTopics.length + partnerTopics.length) * 3}-{(myTopics.length + partnerTopics.length) * 5} minutes
+                </p>
+              </div>
+            </Card>
+          )}
+
+          {/* Action Buttons */}
+          <div className="flex justify-between pt-4 border-t border-rose-100">
+            <Button 
+              variant="outline" 
+              onClick={closePreparationModal}
+              className="border-rose-200 text-rose-600 hover:bg-rose-50"
+            >
+              Save for Later
+            </Button>
+            <Button 
+              onClick={closePreparationModal}
+              disabled={myTopics.length === 0}
+              className="bg-gradient-to-r from-rose-500 to-pink-500 hover:from-rose-600 hover:to-pink-600 text-white border-0"
+            >
+              Start Check-In with Topics
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/bookends/ReflectionForm.tsx
+++ b/src/components/bookends/ReflectionForm.tsx
@@ -1,0 +1,341 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Card } from '@/components/ui/card'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Heart, Sparkles, TrendingUp, Share2, Lock, ChevronRight } from 'lucide-react'
+import { useBookends } from '@/contexts/BookendsContext'
+import { FEELING_EMOJIS } from '@/types/bookends'
+import { cn } from '@/lib/utils'
+import confetti from 'canvas-confetti'
+
+interface ReflectionFormProps {
+  sessionId: string
+}
+
+export function ReflectionForm({ sessionId }: ReflectionFormProps) {
+  const {
+    reflection,
+    partnerReflection,
+    isReflectionModalOpen,
+    closeReflectionModal,
+    saveReflection,
+    simulatePartnerReflection
+  } = useBookends()
+
+  const [feelingBefore, setFeelingBefore] = useState(3)
+  const [feelingAfter, setFeelingAfter] = useState(4)
+  const [gratitude, setGratitude] = useState('')
+  const [keyTakeaway, setKeyTakeaway] = useState('')
+  const [shareWithPartner, setShareWithPartner] = useState(true)
+  const [showPartnerReflection, setShowPartnerReflection] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Simulate partner reflection after saving
+  useEffect(() => {
+    if (reflection && !partnerReflection) {
+      simulatePartnerReflection(sessionId)
+      
+      // Show partner reflection after delay
+      setTimeout(() => {
+        setShowPartnerReflection(true)
+      }, 3000)
+    }
+  }, [reflection, partnerReflection, sessionId, simulatePartnerReflection])
+
+  const handleSubmit = async () => {
+    if (!gratitude.trim() || !keyTakeaway.trim()) return
+
+    setIsSubmitting(true)
+    
+    // Save reflection
+    saveReflection({
+      sessionId,
+      authorId: 'demo-user-1',
+      feelingBefore,
+      feelingAfter,
+      gratitude: gratitude.trim(),
+      keyTakeaway: keyTakeaway.trim(),
+      shareWithPartner
+    })
+
+    // Trigger confetti if feeling improved
+    if (feelingAfter > feelingBefore) {
+      confetti({
+        particleCount: 100,
+        spread: 70,
+        origin: { y: 0.6 }
+      })
+    }
+
+    setIsSubmitting(false)
+  }
+
+  const feelingImprovement = feelingAfter - feelingBefore
+
+  return (
+    <Dialog open={isReflectionModalOpen} onOpenChange={closeReflectionModal}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto bg-white/95 backdrop-blur-md border-rose-200/40">
+        <DialogHeader>
+          <DialogTitle className="text-2xl font-bold bg-gradient-to-r from-rose-500 to-pink-500 bg-clip-text text-transparent">
+            Reflect on Your Session
+          </DialogTitle>
+          <DialogDescription className="text-gray-600">
+            Take a moment to capture your thoughts and feelings after the check-in.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!reflection ? (
+          <div className="space-y-6 mt-4">
+            {/* Mood Comparison */}
+            <div className="space-y-4">
+              <div>
+                <Label className="text-sm font-medium text-rose-700">
+                  How did you feel before the session?
+                </Label>
+                <div className="flex gap-3 mt-3">
+                  {FEELING_EMOJIS.map((emoji) => (
+                    <motion.button
+                      key={emoji.value}
+                      whileHover={{ scale: 1.1 }}
+                      whileTap={{ scale: 0.95 }}
+                      onClick={() => setFeelingBefore(emoji.value)}
+                      className={cn(
+                        "flex flex-col items-center gap-1 p-3 rounded-lg transition-all",
+                        feelingBefore === emoji.value
+                          ? "bg-pink-100 border-2 border-pink-300"
+                          : "bg-gray-50 border-2 border-transparent hover:bg-gray-100"
+                      )}
+                    >
+                      <span className="text-2xl">{emoji.emoji}</span>
+                      <span className="text-xs text-gray-600">{emoji.label}</span>
+                    </motion.button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <Label className="text-sm font-medium text-rose-700">
+                  How do you feel after the session?
+                </Label>
+                <div className="flex gap-3 mt-3">
+                  {FEELING_EMOJIS.map((emoji) => (
+                    <motion.button
+                      key={emoji.value}
+                      whileHover={{ scale: 1.1 }}
+                      whileTap={{ scale: 0.95 }}
+                      onClick={() => setFeelingAfter(emoji.value)}
+                      className={cn(
+                        "flex flex-col items-center gap-1 p-3 rounded-lg transition-all",
+                        feelingAfter === emoji.value
+                          ? "bg-green-100 border-2 border-green-300"
+                          : "bg-gray-50 border-2 border-transparent hover:bg-gray-100"
+                      )}
+                    >
+                      <span className="text-2xl">{emoji.emoji}</span>
+                      <span className="text-xs text-gray-600">{emoji.label}</span>
+                    </motion.button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Mood Change Indicator */}
+              {feelingImprovement !== 0 && (
+                <motion.div
+                  initial={{ opacity: 0, y: -10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className={cn(
+                    "flex items-center gap-2 p-3 rounded-lg",
+                    feelingImprovement > 0 
+                      ? "bg-green-50 text-green-700"
+                      : "bg-orange-50 text-orange-700"
+                  )}
+                >
+                  <TrendingUp className={cn(
+                    "h-4 w-4",
+                    feelingImprovement < 0 && "rotate-180"
+                  )} />
+                  <span className="text-sm">
+                    {feelingImprovement > 0 
+                      ? `Your mood improved by ${feelingImprovement} ${feelingImprovement === 1 ? 'level' : 'levels'}!`
+                      : `Something to work through - your mood shifted by ${Math.abs(feelingImprovement)} ${Math.abs(feelingImprovement) === 1 ? 'level' : 'levels'}`
+                    }
+                  </span>
+                </motion.div>
+              )}
+            </div>
+
+            {/* Gratitude Input */}
+            <div>
+              <Label htmlFor="gratitude" className="text-sm font-medium text-rose-700">
+                <Heart className="inline h-4 w-4 mr-1 text-pink-500" />
+                One thing you appreciated about your partner today
+              </Label>
+              <Textarea
+                id="gratitude"
+                value={gratitude}
+                onChange={(e) => setGratitude(e.target.value)}
+                placeholder="I appreciated how you..."
+                className="mt-2 min-h-[80px]"
+                maxLength={200}
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                {gratitude.length}/200 characters
+              </p>
+            </div>
+
+            {/* Key Takeaway */}
+            <div>
+              <Label htmlFor="takeaway" className="text-sm font-medium text-rose-700">
+                <Sparkles className="inline h-4 w-4 mr-1 text-purple-500" />
+                Your biggest insight from this session
+              </Label>
+              <Textarea
+                id="takeaway"
+                value={keyTakeaway}
+                onChange={(e) => setKeyTakeaway(e.target.value)}
+                placeholder="My main takeaway is..."
+                className="mt-2 min-h-[80px]"
+                maxLength={300}
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                {keyTakeaway.length}/300 characters
+              </p>
+            </div>
+
+            {/* Privacy Toggle */}
+            <Card className="p-4 bg-gray-50">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  {shareWithPartner ? (
+                    <Share2 className="h-4 w-4 text-blue-500" />
+                  ) : (
+                    <Lock className="h-4 w-4 text-gray-500" />
+                  )}
+                  <Label htmlFor="share" className="text-sm font-medium cursor-pointer">
+                    Share reflection with Jordan
+                  </Label>
+                </div>
+                <Switch
+                  id="share"
+                  checked={shareWithPartner}
+                  onCheckedChange={setShareWithPartner}
+                />
+              </div>
+              <p className="text-xs text-gray-600 mt-2">
+                {shareWithPartner 
+                  ? "Jordan will be able to see your reflection after they complete theirs"
+                  : "Your reflection will be kept private"}
+              </p>
+            </Card>
+
+            {/* Action Buttons */}
+            <div className="flex justify-between pt-4 border-t border-rose-100">
+              <Button 
+                variant="outline" 
+                onClick={closeReflectionModal}
+                className="border-rose-200 text-rose-600 hover:bg-rose-50"
+              >
+                Skip for Now
+              </Button>
+              <Button 
+                onClick={handleSubmit}
+                disabled={!gratitude.trim() || !keyTakeaway.trim() || isSubmitting}
+                className="bg-gradient-to-r from-rose-500 to-pink-500 hover:from-rose-600 hover:to-pink-600 text-white border-0"
+              >
+                Save Reflection
+                <ChevronRight className="h-4 w-4 ml-1" />
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-6 mt-4">
+            {/* Success State */}
+            <motion.div
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              className="text-center py-8"
+            >
+              <div className="text-5xl mb-4">🎉</div>
+              <h3 className="text-lg font-semibold text-gray-900">
+                Reflection Saved!
+              </h3>
+              <p className="text-sm text-gray-600 mt-2">
+                Great job taking time to reflect on your session.
+              </p>
+            </motion.div>
+
+            {/* Your Reflection Summary */}
+            <Card className="p-4 bg-pink-50 border-pink-200">
+              <h4 className="text-sm font-medium text-rose-700 mb-3">Your Reflection</h4>
+              <div className="space-y-2 text-sm">
+                <div className="flex gap-2">
+                  <span>Mood:</span>
+                  <span>
+                    {FEELING_EMOJIS[feelingBefore - 1].emoji} → {FEELING_EMOJIS[feelingAfter - 1].emoji}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-gray-600">Gratitude:</span>
+                  <p className="mt-1">{gratitude}</p>
+                </div>
+                <div>
+                  <span className="text-gray-600">Takeaway:</span>
+                  <p className="mt-1">{keyTakeaway}</p>
+                </div>
+              </div>
+            </Card>
+
+            {/* Partner Reflection */}
+            {showPartnerReflection && partnerReflection && (
+              <AnimatePresence>
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.5 }}
+                >
+                  <Card className="p-4 bg-blue-50 border-blue-200">
+                    <h4 className="text-sm font-medium text-rose-700 mb-3">
+                      Jordan&apos;s Reflection
+                    </h4>
+                    <div className="space-y-2 text-sm">
+                      <div className="flex gap-2">
+                        <span>Mood:</span>
+                        <span>
+                          {FEELING_EMOJIS[partnerReflection.feelingBefore - 1].emoji} → {FEELING_EMOJIS[partnerReflection.feelingAfter - 1].emoji}
+                        </span>
+                      </div>
+                      <div>
+                        <span className="text-gray-600">Gratitude:</span>
+                        <p className="mt-1">{partnerReflection.gratitude}</p>
+                      </div>
+                      <div>
+                        <span className="text-gray-600">Takeaway:</span>
+                        <p className="mt-1">{partnerReflection.keyTakeaway}</p>
+                      </div>
+                    </div>
+                  </Card>
+                </motion.div>
+              </AnimatePresence>
+            )}
+
+            {/* Close Button */}
+            <div className="flex justify-center pt-4 border-t border-rose-100">
+              <Button 
+                onClick={closeReflectionModal}
+                className="bg-gradient-to-r from-rose-500 to-pink-500 hover:from-rose-600 hover:to-pink-600 text-white border-0"
+              >
+                Return to Dashboard
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -18,7 +18,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/contexts/BookendsContext.tsx
+++ b/src/contexts/BookendsContext.tsx
@@ -1,0 +1,328 @@
+'use client'
+
+import React, { createContext, useContext, useReducer, useCallback, useEffect } from 'react'
+import { 
+  BookendsState, 
+  SessionPreparation, 
+  QuickReflection, 
+  PreparationTopic,
+  PARTNER_TOPIC_TEMPLATES 
+} from '@/types/bookends'
+import { toast } from 'sonner'
+
+const STORAGE_KEY = 'qc_session_bookends'
+
+interface BookendsContextValue extends BookendsState {
+  // Preparation actions
+  addMyTopic: (content: string, isQuickTopic?: boolean) => void
+  removeMyTopic: (topicId: string) => void
+  reorderMyTopics: (topics: PreparationTopic[]) => void
+  clearPreparation: () => void
+  openPreparationModal: () => void
+  closePreparationModal: () => void
+  
+  // Reflection actions
+  saveReflection: (reflection: Omit<QuickReflection, 'id' | 'createdAt'>) => void
+  openReflectionModal: () => void
+  closeReflectionModal: () => void
+  
+  // Mock partner actions (for POC)
+  simulatePartnerTopics: () => void
+  simulatePartnerReflection: (sessionId: string) => void
+}
+
+type BookendsAction = 
+  | { type: 'ADD_MY_TOPIC'; payload: { content: string; isQuickTopic: boolean } }
+  | { type: 'REMOVE_MY_TOPIC'; payload: { topicId: string } }
+  | { type: 'REORDER_MY_TOPICS'; payload: { topics: PreparationTopic[] } }
+  | { type: 'SET_PARTNER_TOPICS'; payload: { topics: PreparationTopic[] } }
+  | { type: 'CLEAR_PREPARATION' }
+  | { type: 'SAVE_REFLECTION'; payload: QuickReflection }
+  | { type: 'SET_PARTNER_REFLECTION'; payload: QuickReflection }
+  | { type: 'OPEN_PREPARATION_MODAL' }
+  | { type: 'CLOSE_PREPARATION_MODAL' }
+  | { type: 'OPEN_REFLECTION_MODAL' }
+  | { type: 'CLOSE_REFLECTION_MODAL' }
+  | { type: 'MARK_PREP_REMINDER_SEEN' }
+  | { type: 'INCREMENT_REFLECTION_STREAK' }
+  | { type: 'LOAD_STATE'; payload: Partial<BookendsState> }
+
+const initialState: BookendsState = {
+  preparation: null,
+  reflection: null,
+  partnerReflection: null,
+  isPreparationModalOpen: false,
+  isReflectionModalOpen: false,
+  hasSeenPrepReminder: false,
+  reflectionStreak: 0
+}
+
+function bookEndsReducer(state: BookendsState, action: BookendsAction): BookendsState {
+  switch (action.type) {
+    case 'ADD_MY_TOPIC': {
+      const newTopic: PreparationTopic = {
+        id: `topic_${Date.now()}`,
+        content: action.payload.content,
+        authorId: 'demo-user-1',
+        isQuickTopic: action.payload.isQuickTopic,
+        priority: state.preparation?.myTopics.length || 0,
+        createdAt: new Date()
+      }
+
+      const preparation = state.preparation || {
+        id: `prep_${Date.now()}`,
+        myTopics: [],
+        partnerTopics: [],
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+
+      return {
+        ...state,
+        preparation: {
+          ...preparation,
+          myTopics: [...preparation.myTopics, newTopic],
+          updatedAt: new Date()
+        }
+      }
+    }
+
+    case 'REMOVE_MY_TOPIC': {
+      if (!state.preparation) return state
+      
+      return {
+        ...state,
+        preparation: {
+          ...state.preparation,
+          myTopics: state.preparation.myTopics.filter(t => t.id !== action.payload.topicId),
+          updatedAt: new Date()
+        }
+      }
+    }
+
+    case 'REORDER_MY_TOPICS': {
+      if (!state.preparation) return state
+      
+      return {
+        ...state,
+        preparation: {
+          ...state.preparation,
+          myTopics: action.payload.topics,
+          updatedAt: new Date()
+        }
+      }
+    }
+
+    case 'SET_PARTNER_TOPICS': {
+      const preparation = state.preparation || {
+        id: `prep_${Date.now()}`,
+        myTopics: [],
+        partnerTopics: [],
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+
+      return {
+        ...state,
+        preparation: {
+          ...preparation,
+          partnerTopics: action.payload.topics,
+          updatedAt: new Date()
+        }
+      }
+    }
+
+    case 'CLEAR_PREPARATION':
+      return {
+        ...state,
+        preparation: null
+      }
+
+    case 'SAVE_REFLECTION':
+      return {
+        ...state,
+        reflection: action.payload,
+        reflectionStreak: state.reflectionStreak + 1
+      }
+
+    case 'SET_PARTNER_REFLECTION':
+      return {
+        ...state,
+        partnerReflection: action.payload
+      }
+
+    case 'OPEN_PREPARATION_MODAL':
+      return { ...state, isPreparationModalOpen: true }
+
+    case 'CLOSE_PREPARATION_MODAL':
+      return { ...state, isPreparationModalOpen: false }
+
+    case 'OPEN_REFLECTION_MODAL':
+      return { ...state, isReflectionModalOpen: true }
+
+    case 'CLOSE_REFLECTION_MODAL':
+      return { ...state, isReflectionModalOpen: false }
+
+    case 'MARK_PREP_REMINDER_SEEN':
+      return { ...state, hasSeenPrepReminder: true }
+
+    case 'INCREMENT_REFLECTION_STREAK':
+      return { ...state, reflectionStreak: state.reflectionStreak + 1 }
+
+    case 'LOAD_STATE':
+      return { ...state, ...action.payload }
+
+    default:
+      return state
+  }
+}
+
+const BookendsContext = createContext<BookendsContextValue | null>(null)
+
+export function BookendsProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(bookEndsReducer, initialState)
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        dispatch({ type: 'LOAD_STATE', payload: parsed })
+      } catch (error) {
+        console.error('Failed to load bookends state:', error)
+      }
+    }
+  }, [])
+
+  // Save to localStorage on state changes
+  useEffect(() => {
+    if (state.preparation || state.reflection) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        preparation: state.preparation,
+        reflection: state.reflection,
+        reflectionStreak: state.reflectionStreak,
+        hasSeenPrepReminder: state.hasSeenPrepReminder
+      }))
+    }
+  }, [state.preparation, state.reflection, state.reflectionStreak, state.hasSeenPrepReminder])
+
+  const addMyTopic = useCallback((content: string, isQuickTopic = false) => {
+    dispatch({ type: 'ADD_MY_TOPIC', payload: { content, isQuickTopic } })
+    toast.success('Topic added')
+  }, [])
+
+  const removeMyTopic = useCallback((topicId: string) => {
+    dispatch({ type: 'REMOVE_MY_TOPIC', payload: { topicId } })
+  }, [])
+
+  const reorderMyTopics = useCallback((topics: PreparationTopic[]) => {
+    dispatch({ type: 'REORDER_MY_TOPICS', payload: { topics } })
+  }, [])
+
+  const clearPreparation = useCallback(() => {
+    dispatch({ type: 'CLEAR_PREPARATION' })
+  }, [])
+
+  const openPreparationModal = useCallback(() => {
+    dispatch({ type: 'OPEN_PREPARATION_MODAL' })
+  }, [])
+
+  const closePreparationModal = useCallback(() => {
+    dispatch({ type: 'CLOSE_PREPARATION_MODAL' })
+  }, [])
+
+  const saveReflection = useCallback((reflection: Omit<QuickReflection, 'id' | 'createdAt'>) => {
+    const fullReflection: QuickReflection = {
+      ...reflection,
+      id: `reflection_${Date.now()}`,
+      createdAt: new Date()
+    }
+    dispatch({ type: 'SAVE_REFLECTION', payload: fullReflection })
+    toast.success('Reflection saved')
+  }, [])
+
+  const openReflectionModal = useCallback(() => {
+    dispatch({ type: 'OPEN_REFLECTION_MODAL' })
+  }, [])
+
+  const closeReflectionModal = useCallback(() => {
+    dispatch({ type: 'CLOSE_REFLECTION_MODAL' })
+  }, [])
+
+  // Mock partner actions for POC
+  const simulatePartnerTopics = useCallback(() => {
+    // Simulate partner adding topics with a delay
+    setTimeout(() => {
+      const randomTopics = PARTNER_TOPIC_TEMPLATES
+        .sort(() => Math.random() - 0.5)
+        .slice(0, 2 + Math.floor(Math.random() * 2))
+        .map((content, index) => ({
+          id: `partner_topic_${Date.now()}_${index}`,
+          content,
+          authorId: 'demo-user-2',
+          isQuickTopic: false,
+          priority: index,
+          createdAt: new Date()
+        }))
+
+      dispatch({ type: 'SET_PARTNER_TOPICS', payload: { topics: randomTopics } })
+      toast('Jordan added topics for discussion', {
+        icon: '👥',
+        duration: 4000
+      })
+    }, 3000 + Math.random() * 2000) // 3-5 second delay
+  }, [])
+
+  const simulatePartnerReflection = useCallback((sessionId: string) => {
+    // Simulate partner completing reflection
+    setTimeout(() => {
+      const mockReflection: QuickReflection = {
+        id: `partner_reflection_${Date.now()}`,
+        sessionId,
+        authorId: 'demo-user-2',
+        feelingBefore: 3,
+        feelingAfter: 5,
+        gratitude: "I appreciated how you listened without judgment when I shared my concerns about work.",
+        keyTakeaway: "We need to make more time for these check-ins - they really help us stay connected.",
+        shareWithPartner: true,
+        createdAt: new Date()
+      }
+
+      dispatch({ type: 'SET_PARTNER_REFLECTION', payload: mockReflection })
+      toast('Jordan shared their reflection with you', {
+        icon: '💭',
+        duration: 4000
+      })
+    }, 2000 + Math.random() * 3000) // 2-5 second delay
+  }, [])
+
+  const value: BookendsContextValue = {
+    ...state,
+    addMyTopic,
+    removeMyTopic,
+    reorderMyTopics,
+    clearPreparation,
+    openPreparationModal,
+    closePreparationModal,
+    saveReflection,
+    openReflectionModal,
+    closeReflectionModal,
+    simulatePartnerTopics,
+    simulatePartnerReflection
+  }
+
+  return (
+    <BookendsContext.Provider value={value}>
+      {children}
+    </BookendsContext.Provider>
+  )
+}
+
+export function useBookends() {
+  const context = useContext(BookendsContext)
+  if (!context) {
+    throw new Error('useBookends must be used within BookendsProvider')
+  }
+  return context
+}

--- a/src/types/bookends.ts
+++ b/src/types/bookends.ts
@@ -1,0 +1,72 @@
+// Session Bookends Types - Pre-session preparation and post-session reflection
+
+export interface PreparationTopic {
+  id: string
+  content: string
+  authorId: string
+  priority?: number
+  isQuickTopic: boolean
+  createdAt: Date
+}
+
+export interface SessionPreparation {
+  id: string
+  sessionId?: string
+  myTopics: PreparationTopic[]
+  partnerTopics: PreparationTopic[] // Mock data in POC
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface QuickReflection {
+  id: string
+  sessionId: string
+  authorId: string
+  feelingBefore: number // 1-5 scale
+  feelingAfter: number // 1-5 scale
+  gratitude: string
+  keyTakeaway: string
+  shareWithPartner: boolean
+  createdAt: Date
+}
+
+export interface BookendsState {
+  preparation: SessionPreparation | null
+  reflection: QuickReflection | null
+  partnerReflection: QuickReflection | null // Mock in POC
+  isPreparationModalOpen: boolean
+  isReflectionModalOpen: boolean
+  hasSeenPrepReminder: boolean
+  reflectionStreak: number
+}
+
+// Quick topic templates
+export const QUICK_TOPICS = [
+  { id: 'wins', label: 'Weekly wins & challenges', icon: '🏆' },
+  { id: 'emotional', label: 'Emotional check-in', icon: '💭' },
+  { id: 'plans', label: 'Upcoming plans', icon: '📅' },
+  { id: 'appreciation', label: 'Appreciation moment', icon: '🙏' },
+  { id: 'concern', label: 'Something on my mind', icon: '💬' },
+  { id: 'goals', label: 'Our shared goals', icon: '🎯' }
+]
+
+// Emoji scale for feelings
+export const FEELING_EMOJIS = [
+  { value: 1, emoji: '😔', label: 'Struggling' },
+  { value: 2, emoji: '😕', label: 'Concerned' },
+  { value: 3, emoji: '😐', label: 'Neutral' },
+  { value: 4, emoji: '😊', label: 'Good' },
+  { value: 5, emoji: '😍', label: 'Great' }
+]
+
+// Mock partner topic templates
+export const PARTNER_TOPIC_TEMPLATES = [
+  'How we handled last week\'s conflict',
+  'Planning for the upcoming holiday',
+  'Budget review and financial goals',
+  'Family visit preparations',
+  'Work-life balance check',
+  'Intimacy and connection',
+  'Household responsibilities',
+  'Future dreams and aspirations'
+]


### PR DESCRIPTION
- Pre-session preparation modal with topic selection
- Quick topic cards and custom topic input
- Mock partner topic simulation (3-5 second delay)
- Post-session reflection form with mood tracking
- Before/after mood comparison with emoji scale
- Gratitude and key takeaway capture
- Share/private toggle for partner visibility
- Mock partner reflection simulation
- Dashboard preparation banner
- Check-in page integration with topic badges
- Toast notifications via sonner library
- Confetti animation for mood improvements
- LocalStorage persistence for state
- Light, romantic theme styling for modals

🤖 Generated with Claude Code (https://claude.ai/code)